### PR TITLE
Bumping the version of Python to 3.5.2

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,10 +2,10 @@ node/node-v6.9.1-linux-x64.tar.xz:
   size: 9351072
   object_id: c76f3e2b-5864-49b7-9dd0-66bb2526b9e6
   sha: 84b0b6fde43a4d892186119ba6b9f1db3c2c6129
-python/Python-3.4.3.tar.xz:
-  size: 14421964
-  object_id: e4a90d84-f05e-4a8d-8d59-a7f26809afdb
-  sha: 7ca5cd664598bea96eec105aa6453223bb6b4456
+python/Python-3.5.2.tar.xz:
+  size: 15222676
+  object_id: 0288c930-bd08-4d77-7edd-62e5d14f04cd
+  sha: 4843aabacec5bc0cdd3e1f778faa926e532794d2
 python/pip-18.1.tar.gz:
   size: 6211295
   object_id: 6b227ef6-401d-4d8a-5fdf-655e72ecfb4d

--- a/packages/python/spec
+++ b/packages/python/spec
@@ -4,4 +4,4 @@ name: python
 dependencies: []
 
 files:
-  - python/Python-3.4.3.tar.xz
+  - python/Python-3.5.2.tar.xz


### PR DESCRIPTION
Updating the version of python since the older version will soon be deprecated.

This version will also fix the discrepancy issues we were facing during local development in JB.