### PR TITLE
NGPBUG-179730 fixing blueprint deployment failure

### DIFF
--- a/packages/python/packaging
+++ b/packages/python/packaging
@@ -6,9 +6,6 @@ set -u
 # We grab the latest versions that are in the directory
 PYTHON_VERSION=`ls -r python/Python-*.tar.xz | sed 's/python\/Python-\(.*\)\.tar\.xz/\1/' | head -1`
 
-sudo apt install libreadline-gplv2-dev libncursesw5-dev libssl-dev \
-	    libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev libffi-dev zlib1g-dev -y
-
 echo "Extracting libffi-3.2.tar.gz ..."
 if ! tar xpvf python/libffi-3.2.tar.gz ; then
   echo "Failed extracting libffi-3.2.tar.gz ..."


### PR DESCRIPTION
Removing redundant line from script 
This line is causing validate-service-fabrik-basic job and validate-update-blueprint job failure in multiple landscape pipeline
Bug: [NGPBUG-179730](https://jtrack.wdf.sap.corp/browse/NGPBUG-179730)